### PR TITLE
Use correct name for Santa Barbara Metropolian Transportation District

### DIFF
--- a/es/projects-es.html
+++ b/es/projects-es.html
@@ -204,7 +204,7 @@
             <ul>
               <li><strong>Octubre de 2023</strong>: Descuento en el transporte público <i>Sacramento Regional
                   Transit</i></li>
-              <li><strong>Octubre de 2023</strong>: Descuento en el transporte público <i>Santa Barbara Transportation
+              <li><strong>Octubre de 2023</strong>: Descuento en el transporte público <i>Santa Barbara Metropolitan Transportation
                   District</i></li>
               <li><strong>Fecha por determinar</strong>: Reembolsos de <i>CARB</i> energía sostenible.</li>
             </ul>

--- a/projects.html
+++ b/projects.html
@@ -225,7 +225,7 @@
             <h4 class="m-t-0">Pilot expansion</h4>
             <ul>
               <li><strong>October 2023</strong>: Transit Discount Sacramento Regional Transit</li>
-              <li><strong>October 2023</strong>: Transit Discount Santa Barbara Transportation District</li>
+              <li><strong>October 2023</strong>: Transit Discount Santa Barbara Metropolitan Transportation District</li>
               <li><strong>Date TBD</strong>: CARB Green Energy Rebates</li>
             </ul>
           </div>


### PR DESCRIPTION
closes #27 

The official name for the transit agency in Santa Barbara is: Santa Barbara Metropolitan Transportation District

https://sbmtd.gov

<img width="1512" alt="image" src="https://github.com/Office-of-Digital-Services/CDT-Digital-ID-Strategy/assets/3673236/081e1737-5294-485f-ad6b-900ff581c685">
