### PR TITLE
Test bugfix/fix spanish homepage brand link

### DIFF
--- a/src/es/index-es.html
+++ b/src/es/index-es.html
@@ -183,7 +183,7 @@ permalink: /es/index-es.html
       <div class="section-default">
         <div class="branding">
           <div class="header-organization-banner">
-            <a href="/es/">
+            <a href="/es/index-es.html/">
               <div class="logo-assets">
                 <img
                   src="/images/blue-gold-fingerprint.png"

--- a/src/es/index-es.html
+++ b/src/es/index-es.html
@@ -183,7 +183,7 @@ permalink: /es/index-es.html
       <div class="section-default">
         <div class="branding">
           <div class="header-organization-banner">
-            <a href="/es/index-es.html/">
+            <a href="/es/index-es.html">
               <div class="logo-assets">
                 <img
                   src="/images/blue-gold-fingerprint.png"


### PR DESCRIPTION
Fix the logo link at the top-left of the page to take you home when you're on spanish pages. 

The issue was that there was an extra slash after the hyperlink - since the link was an absolute link to the page, it needed to end in just the .html extension, not with a trailing forward slash

<img width="832" height="56" alt="image" src="https://github.com/user-attachments/assets/321c4cfc-fe9e-416b-8dbc-7844e809f43b" />
