### PR TITLE
switching to statewide only for performance

### DIFF
--- a/pages/_includes/base-layout.html
+++ b/pages/_includes/base-layout.html
@@ -58,8 +58,6 @@
       (function() {
         // --- REQUIRED: Statewide GA4 ID (do not change) ---
         const SW = "G-69TD0KNT0F"; //G-69TD0KNT0F
-        // --- REQUIRED: Site-specific GA4 ID (developers replace this) ---
-        const SITE = "G-CLMC17ZTJT"; // Replace with your site's GA4 ID
         function loadGA4() {
           // Load gtag.js once (using statewide ID)
           const s = document.createElement("script");
@@ -76,11 +74,6 @@
           // --- Statewide GA4 (uses .ca.gov second‑level domain cookie) ---
           gtag("config", SW, {
             cookie_flags: "secure;samesite=lax"
-          });
-
-          // --- Site-specific GA4 (full-hostname cookie) ---
-          gtag("config", SITE, {
-            cookie_flags: "secure;samesite=lax;domain="
           });
         }
 


### PR DESCRIPTION
Switching to just statewide G-69 for analytics to maximize performance.